### PR TITLE
fix(run): allow run on forks

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -18,7 +18,6 @@ on:
 
 jobs:
   run:
-    if: github.repository_owner == 'bombshell-dev'
     runs-on: ubuntu-latest
 
     strategy:


### PR DESCRIPTION
`run` was checking `if: github.repository_owner == 'bombshell-dev'` which is good for cron jobs and expensive workflows, but makes contributing from a fork impossible. This should fix the issue!