### PR TITLE
chore: update npm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,6 +41,9 @@ jobs:
           registry-url: https://registry.npmjs.org/
           cache: "pnpm"
 
+      - name: Update NPM
+        run: npm install -g npm@latest
+
       - name: Install dependencies
         run: pnpm install
 


### PR DESCRIPTION
This forces npm to be `latest` so we can get OIDC publishing.
