### PR TITLE
chore(publish): set bombshell-bot as git user

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,6 +31,11 @@ jobs:
           ref: ${{ github.head_ref }}
           token: ${{ steps.bot-token.outputs.token }}
 
+      - name: Setup git user
+        run: |
+          git config --global user.name "bombshell-bot[bot]"
+          git config --global user.email "187071675+bombshell-bot[bot]@users.noreply.github.com"
+
       - name: Setup PNPM
         uses: pnpm/action-setup@v4
 
@@ -58,6 +63,7 @@ jobs:
           publish: pnpm exec changeset publish
           commit: "[ci] release"
           title: "[ci] release"
+          setupGitUser: false
         env:
           GITHUB_TOKEN: ${{ steps.bot-token.outputs.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Currently when cutting releases, it's attributed to both bombshell-bot and github-actions bot, e.g. https://github.com/bombshell-dev/clack/commit/73b88da8a34118555f27290b2b175f5c35ddef30

This is because the changesets action by default would use github-actions bot for commits in the release PR. It's possible to change this to the bombshell-bot so that commits are done through it instead. ([I did this for my repo before](https://github.com/publint/publint/commit/6826b0a8dd3a205657293fa62689cc69c4206405))

The bombshell-bot git user name and email is retrieved from https://github.com/bombshell-dev/clack/commit/73b88da8a34118555f27290b2b175f5c35ddef30.patch.


Just a really small improvement I thought worth having.