### PR TITLE
Remove NPM_TOKEN from publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,9 +3,6 @@ name: publish
 on:
   workflow_call:
     secrets:
-      NPM_TOKEN:
-        description: 'A token for publishing to the NPM registry'
-        required: true
       BOT_APP_ID:
         description: 'The GitHub App ID for authenticating with the GitHub API'
         required: true
@@ -66,4 +63,3 @@ jobs:
           setupGitUser: false
         env:
           GITHUB_TOKEN: ${{ steps.bot-token.outputs.token }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Remove NPM_TOKEN from workflow secrets since we're using trusted publishing now