### PR TITLE
feat(detect-agent): add detect-agent workflow

### DIFF
--- a/.github/workflows/detect-agent-backfill.yml
+++ b/.github/workflows/detect-agent-backfill.yml
@@ -1,0 +1,111 @@
+name: detect-agent-backfill
+
+on:
+  workflow_call:
+    inputs:
+      LABEL:
+        description: >
+          Label to apply when the PR author is classified as automated.
+        default: "automated"
+        type: string
+        required: false
+      BYPASS_MEMBERS:
+        description: >
+          Skip scanning for org members and collaborators.
+        default: true
+        type: boolean
+        required: false
+
+jobs:
+  backfill:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          repository: "bombshell-dev/automation"
+          ref: "main"
+          path: "automation"
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Ensure label exists
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh label create "${{ inputs.LABEL }}" --repo ${{ github.repository }} --color "D93F0B" --description "PR author detected as automated" --force
+
+      - name: Scan open PRs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
+          LABEL: ${{ inputs.LABEL }}
+          BYPASS_MEMBERS: ${{ inputs.BYPASS_MEMBERS }}
+        run: |
+          set -euo pipefail
+
+          # Get all open PRs with author info
+          PRS=$(gh pr list --repo "$GITHUB_REPOSITORY" --state open --json number,author --limit 999)
+          if [ "$(echo "$PRS" | jq 'length')" -eq 0 ]; then
+            echo "No open PRs found"
+            exit 0
+          fi
+
+          # Build unique authors map: { "author": [pr_numbers] }
+          AUTHORS=$(echo "$PRS" | jq -r '
+            group_by(.author.login)
+            | map({ key: .[0].author.login, value: [.[].number] })
+            | from_entries
+          ')
+
+          for AUTHOR in $(echo "$AUTHORS" | jq -r 'keys[]'); do
+            PR_NUMS=$(echo "$AUTHORS" | jq -r --arg a "$AUTHOR" '.[$a] | map(tostring) | join(",")')
+            echo "::group::$AUTHOR (PRs: $PR_NUMS)"
+
+            # Bot check: [bot] suffix means GitHub App bot account
+            if [[ "$AUTHOR" == *"[bot]" ]]; then
+              echo "Bot account detected, labeling PRs"
+              for PR in $(echo "$AUTHORS" | jq -r --arg a "$AUTHOR" '.[$a][]'); do
+                gh pr edit "$PR" --repo "$GITHUB_REPOSITORY" --add-label "$LABEL" || true
+              done
+              echo "::endgroup::"
+              continue
+            fi
+
+            # Collaborator check
+            if [[ "$BYPASS_MEMBERS" == "true" ]]; then
+              STATUS=$(gh api "repos/$GITHUB_REPOSITORY/collaborators/$AUTHOR" --silent -i 2>&1 | head -1 | awk '{print $2}')
+              if [[ "$STATUS" == "204" ]]; then
+                echo "Skipping collaborator"
+                echo "::endgroup::"
+                continue
+              fi
+            fi
+
+            # Run detect-agent with --json for structured output
+            export PR_AUTHOR="$AUTHOR"
+            RESULT=$(node automation/dist/detect-agent.mjs --json) || {
+              echo "::warning::Failed to analyze $AUTHOR"
+              echo "::endgroup::"
+              continue
+            }
+
+            IS_AGENT=$(echo "$RESULT" | jq -r '.isAgent')
+            COMMENT=$(echo "$RESULT" | jq -r '.comment')
+
+            if [[ "$IS_AGENT" == "true" ]]; then
+              echo "Flagged as automated, labeling + commenting"
+              for PR in $(echo "$AUTHORS" | jq -r --arg a "$AUTHOR" '.[$a][]'); do
+                gh pr edit "$PR" --repo "$GITHUB_REPOSITORY" --add-label "$LABEL" || true
+                if [ -n "$COMMENT" ]; then
+                  gh pr comment "$PR" --repo "$GITHUB_REPOSITORY" --body "$COMMENT" || true
+                fi
+              done
+            else
+              echo "Not flagged"
+            fi
+
+            echo "::endgroup::"
+          done

--- a/.github/workflows/detect-agent.yml
+++ b/.github/workflows/detect-agent.yml
@@ -1,0 +1,127 @@
+name: detect-agent
+
+on:
+  workflow_call:
+    inputs:
+      LABEL:
+        description: >
+          Label to apply when the PR author is classified as automated.
+        default: "automated"
+        type: string
+        required: false
+      BYPASS_MEMBERS:
+        description: >
+          Skip scanning for org members and collaborators.
+        default: true
+        type: boolean
+        required: false
+    outputs:
+      classification:
+        description: "The classification result: organic, mixed, or automation"
+        value: ${{ jobs.detect.outputs.classification }}
+      score:
+        description: "The raw score from voight-kampff-test"
+        value: ${{ jobs.detect.outputs.score }}
+      is_agent:
+        description: "Whether the PR author is classified as automated (true/false)"
+        value: ${{ jobs.detect.outputs.is_agent }}
+
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    outputs:
+      classification: ${{ steps.analyze.outputs.CLASSIFICATION }}
+      score: ${{ steps.analyze.outputs.SCORE }}
+      is_agent: ${{ steps.analyze.outputs.IS_AGENT }}
+    steps:
+      - name: Check scan cache
+        id: cache
+        uses: actions/cache/restore@v4
+        with:
+          path: .scan-marker
+          key: detect-agent-pr-${{ github.event.pull_request.number }}
+
+      - name: Check for bypass
+        if: steps.cache.outputs.cache-hit != 'true'
+        id: bypass
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          BYPASS_MEMBERS: ${{ inputs.BYPASS_MEMBERS }}
+        run: |
+          # Fast-path: [bot] suffix means GitHub App bot account
+          if [[ "$PR_AUTHOR" == *"[bot]" ]]; then
+            echo "is_bot=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Check org membership
+          if [[ "$BYPASS_MEMBERS" == "true" ]]; then
+            STATUS=$(gh api repos/${{ github.repository }}/collaborators/$PR_AUTHOR --silent -i 2>&1 | head -1 | awk '{print $2}')
+            if [[ "$STATUS" == "204" ]]; then
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+            fi
+          fi
+
+      - name: Label bot account
+        if: steps.cache.outputs.cache-hit != 'true' && steps.bypass.outputs.is_bot == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh label create "${{ inputs.LABEL }}" --repo ${{ github.repository }} --color "D93F0B" --description "PR author detected as automated" --force
+          gh pr edit ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --add-label "${{ inputs.LABEL }}"
+
+      - name: Checkout
+        if: steps.cache.outputs.cache-hit != 'true' && steps.bypass.outputs.is_bot != 'true' && steps.bypass.outputs.skip != 'true'
+        uses: actions/checkout@v4
+        with:
+          repository: "bombshell-dev/automation"
+          ref: "main"
+          path: "automation"
+
+      - name: Setup Node
+        if: steps.cache.outputs.cache-hit != 'true' && steps.bypass.outputs.is_bot != 'true' && steps.bypass.outputs.skip != 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        if: steps.cache.outputs.cache-hit != 'true' && steps.bypass.outputs.is_bot != 'true' && steps.bypass.outputs.skip != 'true'
+        run: npm install --prefix automation
+
+      - id: analyze
+        name: Analyze PR author
+        if: steps.cache.outputs.cache-hit != 'true' && steps.bypass.outputs.is_bot != 'true' && steps.bypass.outputs.skip != 'true'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: node automation/dist/detect-agent.mjs
+
+      - name: Ensure label exists
+        if: steps.cache.outputs.cache-hit != 'true' && steps.bypass.outputs.is_bot != 'true' && steps.bypass.outputs.skip != 'true' && steps.analyze.outputs.IS_AGENT == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh label create "${{ inputs.LABEL }}" --repo ${{ github.repository }} --color "D93F0B" --description "PR author detected as automated" --force
+
+      - name: Add label
+        if: steps.cache.outputs.cache-hit != 'true' && steps.bypass.outputs.is_bot != 'true' && steps.bypass.outputs.skip != 'true' && steps.analyze.outputs.IS_AGENT == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh pr edit ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --add-label "${{ inputs.LABEL }}"
+
+      - name: Comment on PR
+        if: steps.cache.outputs.cache-hit != 'true' && steps.bypass.outputs.is_bot != 'true' && steps.bypass.outputs.skip != 'true' && steps.analyze.outputs.IS_AGENT == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          COMMENT_BODY: ${{ steps.analyze.outputs.COMMENT }}
+        run: gh pr comment ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --body "$COMMENT_BODY"
+
+      - name: Create scan marker
+        if: steps.cache.outputs.cache-hit != 'true' && steps.bypass.outputs.is_bot != 'true' && steps.bypass.outputs.skip != 'true'
+        run: echo "scanned" > .scan-marker
+
+      - name: Save scan cache
+        if: steps.cache.outputs.cache-hit != 'true' && steps.bypass.outputs.is_bot != 'true' && steps.bypass.outputs.skip != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: .scan-marker
+          key: detect-agent-pr-${{ github.event.pull_request.number }}

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ All workflows are [reusable](https://docs.github.com/en/actions/sharing-automati
 | [publish](docs/publish.md) | Create release PRs or publish to npm via changesets |
 | [add-issue-to-project](docs/add-issue-to-project.md) | Add new issues to the GitHub Project with "Needs triage" status |
 | [move-issue-to-backlog](docs/move-issue-to-backlog.md) | Move closed issues to "Backlog" in the GitHub Project |
+| [detect-agent](docs/detect-agent.md) | Detect automated PR authors and label them |
 
 ## Acknowledgements
 

--- a/docs/detect-agent.md
+++ b/docs/detect-agent.md
@@ -1,0 +1,66 @@
+# detect-agent
+
+Detects automated (bot/agent) PR authors using [`voight-kampff-test`](https://www.npmx.dev/package/voight-kampff-test) which powers [AgentScan](https://agentscan.netlify.app/). Analyzes public GitHub activity to classify accounts as `organic`, `mixed`, or `automation`.
+
+- `[bot]` accounts are labeled immediately without analysis
+- Organization members and collaborators are bypassed by default
+- Regular accounts are analyzed and, if flagged, labeled and commented on with a breakdown of signals
+- Results are cached per PR to avoid redundant scans
+
+## Inputs
+
+| Name             | Type      | Required | Default       | Description                                                   |
+| ---------------- | --------- | -------- | ------------- | ------------------------------------------------------------- |
+| `LABEL`          | `string`  | No       | `"automated"` | Label to apply when the PR author is classified as automated. |
+| `BYPASS_MEMBERS` | `boolean` | No       | `true`        | Skip scanning for org members and collaborators.              |
+
+## Outputs
+
+| Name             | Description                                                       |
+| ---------------- | ----------------------------------------------------------------- |
+| `classification` | The classification result: `organic`, `mixed`, or `automation`    |
+| `score`          | The raw score from voight-kampff-test                             |
+| `is_agent`       | Whether the PR author is classified as automated (`true`/`false`) |
+
+## Secrets
+
+None beyond the default `github.token`.
+
+## Usage
+
+```yaml
+name: Detect agent
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  detect:
+    uses: bombshell-dev/automation/.github/workflows/detect-agent.yml@main
+```
+
+### Custom label
+
+```yaml
+jobs:
+  detect:
+    uses: bombshell-dev/automation/.github/workflows/detect-agent.yml@main
+    with:
+      LABEL: "bot"
+```
+
+### Using outputs
+
+```yaml
+jobs:
+  detect:
+    uses: bombshell-dev/automation/.github/workflows/detect-agent.yml@main
+
+  review:
+    needs: detect
+    if: needs.detect.outputs.is_agent != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "PR is from a human (${{ needs.detect.outputs.classification }})"
+```

--- a/docs/detect-agent.md
+++ b/docs/detect-agent.md
@@ -40,6 +40,28 @@ jobs:
     uses: bombshell-dev/automation/.github/workflows/detect-agent.yml@main
 ```
 
+### With backfill support
+
+Scan new PRs automatically and backfill all open PRs on demand via `workflow_dispatch`.
+
+```yaml
+name: Detect agent
+
+on:
+  pull_request_target:
+    types: [opened]
+  workflow_dispatch: {}
+
+jobs:
+  detect:
+    if: github.event_name != 'workflow_dispatch'
+    uses: bombshell-dev/automation/.github/workflows/detect-agent.yml@main
+
+  backfill:
+    if: github.event_name == 'workflow_dispatch'
+    uses: bombshell-dev/automation/.github/workflows/detect-agent-backfill.yml@main
+```
+
 ### Custom label
 
 ```yaml

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     },
     "devDependencies": {
         "@bomb.sh/tools": "^0.2.1",
-        "@types/node": "^22.19.15"
+        "@types/node": "^22.19.15",
+        "voight-kampff-test": "^2.2.0"
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@types/node':
         specifier: ^22.19.15
         version: 22.19.15
+      voight-kampff-test:
+        specifier: ^2.2.0
+        version: 2.2.0
 
 packages:
 
@@ -1112,6 +1115,9 @@ packages:
       jsdom:
         optional: true
 
+  voight-kampff-test@2.2.0:
+    resolution: {integrity: sha512-ri+tLpJvpNccHc6IWJHdF6wEKdXpE5xZH3Wc8WAGDiEi0zjJgjEWSA78czapPxiudUDLlv/nOqG8DeLUJK29gQ==}
+
   walk-up-path@4.0.0:
     resolution: {integrity: sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==}
     engines: {node: 20 || >=22}
@@ -2015,6 +2021,8 @@ snapshots:
       '@types/node': 22.19.15
     transitivePeerDependencies:
       - msw
+
+  voight-kampff-test@2.2.0: {}
 
   walk-up-path@4.0.0: {}
 

--- a/src/detect-agent.ts
+++ b/src/detect-agent.ts
@@ -1,0 +1,67 @@
+import { identifyReplicant } from "voight-kampff-test";
+import { setOutput } from "./utils";
+
+const { GITHUB_TOKEN, PR_AUTHOR } = process.env;
+if (!GITHUB_TOKEN || !PR_AUTHOR) {
+	throw new Error(
+		`Missing input.\nRequired environment variables: GITHUB_TOKEN, PR_AUTHOR\n`,
+	);
+}
+
+const headers = {
+	Accept: "application/vnd.github+json",
+	Authorization: `Bearer ${GITHUB_TOKEN}`,
+	"X-GitHub-Api-Version": "2022-11-28",
+};
+
+const userRes = await fetch(`https://api.github.com/users/${PR_AUTHOR}`, {
+	headers,
+});
+if (!userRes.ok) {
+	throw new Error(`Failed to fetch user ${PR_AUTHOR}: ${userRes.status}`);
+}
+const user = await userRes.json();
+
+// Fetch up to 2 pages of public events (200 max)
+const events = [];
+for (let page = 1; page <= 2; page++) {
+	const eventsRes = await fetch(
+		`https://api.github.com/users/${PR_AUTHOR}/events/public?per_page=100&page=${page}`,
+		{ headers },
+	);
+	if (!eventsRes.ok) break;
+	const pageEvents = await eventsRes.json();
+	events.push(...pageEvents);
+	if (pageEvents.length < 100) break;
+}
+
+const { classification, score, flags } = identifyReplicant({
+	accountName: PR_AUTHOR,
+	reposCount: user.public_repos,
+	createdAt: user.created_at,
+	events,
+});
+
+console.log(`Classification: ${classification} (score: ${score})`);
+for (const flag of flags) {
+	console.log(`  [${flag.points > 0 ? "+" : ""}${flag.points}] ${flag.label}: ${flag.detail}`);
+}
+
+setOutput("CLASSIFICATION", classification);
+setOutput("SCORE", String(score));
+setOutput("IS_AGENT", classification === "automation" ? "true" : "false");
+
+const flagsTable = flags
+	.map((f) => `| ${f.label} | ${f.points > 0 ? "+" : ""}${f.points} | ${f.detail} |`)
+	.join("\n");
+setOutput("COMMENT", `### 🤖 Automated account detected
+
+[@${PR_AUTHOR}](https://github.com/${PR_AUTHOR}) has been flagged as a likely automated account.
+
+**Classification:** \`${classification}\` (score: ${score})
+
+| Signal | Points | Detail |
+|--------|--------|--------|
+${flagsTable}
+
+<sub>Analyzed ${events.length} public events via <a href="https://www.npmjs.com/package/voight-kampff-test">voight-kampff-test</a></sub>`);

--- a/src/detect-agent.ts
+++ b/src/detect-agent.ts
@@ -1,6 +1,8 @@
 import { identifyReplicant } from "voight-kampff-test";
 import { setOutput } from "./utils";
 
+const jsonMode = process.argv.includes("--json");
+
 const { GITHUB_TOKEN, PR_AUTHOR } = process.env;
 if (!GITHUB_TOKEN || !PR_AUTHOR) {
 	throw new Error(
@@ -42,19 +44,11 @@ const { classification, score, flags } = identifyReplicant({
 	events,
 });
 
-console.log(`Classification: ${classification} (score: ${score})`);
-for (const flag of flags) {
-	console.log(`  [${flag.points > 0 ? "+" : ""}${flag.points}] ${flag.label}: ${flag.detail}`);
-}
-
-setOutput("CLASSIFICATION", classification);
-setOutput("SCORE", String(score));
-setOutput("IS_AGENT", classification === "automation" ? "true" : "false");
-
+const isAgent = classification === "automation";
 const flagsTable = flags
 	.map((f) => `| ${f.label} | ${f.points > 0 ? "+" : ""}${f.points} | ${f.detail} |`)
 	.join("\n");
-setOutput("COMMENT", `### 🤖 Automated account detected
+const comment = `### 🤖 Automated account detected
 
 [@${PR_AUTHOR}](https://github.com/${PR_AUTHOR}) has been flagged as a likely automated account.
 
@@ -64,4 +58,19 @@ setOutput("COMMENT", `### 🤖 Automated account detected
 |--------|--------|--------|
 ${flagsTable}
 
-<sub>Analyzed ${events.length} public events via <a href="https://www.npmx.dev/package/voight-kampff-test">voight-kampff-test</a></sub>`);
+<sub>Analyzed ${events.length} public events via <a href="https://www.npmx.dev/package/voight-kampff-test">voight-kampff-test</a></sub>`;
+
+const log = jsonMode ? console.error : console.log;
+log(`Classification: ${classification} (score: ${score})`);
+for (const flag of flags) {
+	log(`  [${flag.points > 0 ? "+" : ""}${flag.points}] ${flag.label}: ${flag.detail}`);
+}
+
+if (jsonMode) {
+	console.log(JSON.stringify({ classification, score, isAgent, comment }));
+} else {
+	setOutput("CLASSIFICATION", classification);
+	setOutput("SCORE", String(score));
+	setOutput("IS_AGENT", isAgent ? "true" : "false");
+	setOutput("COMMENT", comment);
+}

--- a/src/detect-agent.ts
+++ b/src/detect-agent.ts
@@ -64,4 +64,4 @@ setOutput("COMMENT", `### 🤖 Automated account detected
 |--------|--------|--------|
 ${flagsTable}
 
-<sub>Analyzed ${events.length} public events via <a href="https://www.npmjs.com/package/voight-kampff-test">voight-kampff-test</a></sub>`);
+<sub>Analyzed ${events.length} public events via <a href="https://www.npmx.dev/package/voight-kampff-test">voight-kampff-test</a></sub>`);


### PR DESCRIPTION
Adds a new `detect-agent` workflow that uses [`voight-kampff-test`](https://npmx.dev/package/voight-kampff-test) to surface GitHub activity signal on PRs. 

PRs by `[bot]` accounts and likely automated regular accounts get an `automated` label. For regular accounts, we add a comment to the PR explaining the results. 

Organization members are automatically bypassed.