### PR TITLE
fix(agent): update permissions

### DIFF
--- a/.github/workflows/detect-agent-backfill.yml
+++ b/.github/workflows/detect-agent-backfill.yml
@@ -19,6 +19,9 @@ on:
 jobs:
   backfill:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/detect-agent.yml
+++ b/.github/workflows/detect-agent.yml
@@ -33,6 +33,9 @@ jobs:
       classification: ${{ steps.analyze.outputs.CLASSIFICATION }}
       score: ${{ steps.analyze.outputs.SCORE }}
       is_agent: ${{ steps.analyze.outputs.IS_AGENT }}
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - name: Check scan cache
         id: cache


### PR DESCRIPTION
agents workflows need permissions to write `issues` and `pull-requests` in order to create labels