### PR TITLE
fix(ci): publish workaround npm/cli#9151

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,6 +48,8 @@ jobs:
           cache: "pnpm"
 
       - name: Update NPM
+        # The latest version of npm breaks itself whilst installing itself
+        # see https://github.com/npm/cli/issues/9151 
         run: npm install -g npm@~11.10.0
 
       - name: Install dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,7 +48,7 @@ jobs:
           cache: "pnpm"
 
       - name: Update NPM
-        run: npm install -g npm@latest
+        run: npm install -g npm@~11.10.0
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,9 +48,11 @@ jobs:
           cache: "pnpm"
 
       - name: Update NPM
-        # The latest version of npm breaks itself whilst installing itself
+        # WORKAROUND: The latest version of npm breaks itself whilst installing itself
         # see https://github.com/npm/cli/issues/9151 
-        run: npm install -g npm@~11.10.0
+        run: |
+          npm install -g npm@~11.10.0
+          npm install -g npm@latest
 
       - name: Install dependencies
         run: pnpm install


### PR DESCRIPTION
Node 22.22.2 ships broken npm missing promise-retry, preventing upgrade to npm. See: https://github.com/npm/cli/issues/9151
related to: https://github.com/bombshell-dev/tab/actions/runs/24902639988/job/72924202908