### PR TITLE
chore: update workflows & move env vars

### DIFF
--- a/.github/workflows/add-issue-to-project.yml
+++ b/.github/workflows/add-issue-to-project.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Generate a token
         id: bot-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
           app-id: ${{ secrets.BOT_APP_ID }}
           private-key: ${{ secrets.BOT_PRIVATE_KEY }}
@@ -79,6 +79,7 @@ jobs:
       - name: Set fields
         env:
           GH_TOKEN: ${{ steps.bot-token.outputs.token }}
+          STATUS_VALUE: ${{ env.OPTION_ID_STATUS_TRIAGE }}
 
         run: |
           gh api graphql -f query='
@@ -100,4 +101,4 @@ jobs:
                   id
                 }
               }
-            }' -f project=$PROJECT_ID -f item=$ITEM_ID -f status_field=$FIELD_ID_STATUS -f status_value=${{ env.OPTION_ID_STATUS_TRIAGE }} --silent
+            }' -f project=$PROJECT_ID -f item=$ITEM_ID -f status_field=$FIELD_ID_STATUS -f status_value=$STATUS_VALUE --silent

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,20 +11,20 @@ jobs:
     steps:
       - name: Generate a token
         id: bot-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
           app-id: ${{ secrets.BOT_APP_ID }}
           private-key: ${{ secrets.BOT_PRIVATE_KEY }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           token: ${{ steps.bot-token.outputs.token }}
 
       - name: Setup PNPM
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/detect-agent-backfill.yml
+++ b/.github/workflows/detect-agent-backfill.yml
@@ -24,21 +24,23 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: "bombshell-dev/automation"
           ref: "main"
           path: "automation"
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
 
       - name: Ensure label exists
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh label create "${{ inputs.LABEL }}" --repo ${{ github.repository }} --color "D93F0B" --description "PR author detected as automated" --force
+          LABEL: ${{ inputs.LABEL }}
+          REPO: ${{ github.repository }}
+        run: gh label create $LABEL --repo $REPO --color "D93F0B" --description "PR author detected as automated" --force
 
       - name: Scan open PRs
         env:

--- a/.github/workflows/detect-agent.yml
+++ b/.github/workflows/detect-agent.yml
@@ -39,7 +39,7 @@ jobs:
     steps:
       - name: Check scan cache
         id: cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: .scan-marker
           key: detect-agent-pr-${{ github.event.pull_request.number }}
@@ -68,13 +68,16 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true' && steps.bypass.outputs.is_bot == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
+          LABEL: ${{ inputs.LABEL }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          gh label create "${{ inputs.LABEL }}" --repo ${{ github.repository }} --color "D93F0B" --description "PR author detected as automated" --force
-          gh pr edit ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --add-label "${{ inputs.LABEL }}"
+          gh label create $LABEL --repo $REPO --color "D93F0B" --description "PR author detected as automated" --force
+          gh pr edit $PR_NUMBER --repo $REPO --add-label $LABEL
 
       - name: Checkout
         if: steps.cache.outputs.cache-hit != 'true' && steps.bypass.outputs.is_bot != 'true' && steps.bypass.outputs.skip != 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: "bombshell-dev/automation"
           ref: "main"
@@ -82,7 +85,7 @@ jobs:
 
       - name: Setup Node
         if: steps.cache.outputs.cache-hit != 'true' && steps.bypass.outputs.is_bot != 'true' && steps.bypass.outputs.skip != 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
 
@@ -102,13 +105,18 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true' && steps.bypass.outputs.is_bot != 'true' && steps.bypass.outputs.skip != 'true' && steps.analyze.outputs.IS_AGENT == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh label create "${{ inputs.LABEL }}" --repo ${{ github.repository }} --color "D93F0B" --description "PR author detected as automated" --force
+          LABEL: ${{ inputs.LABEL }}
+          REPO: ${{ github.repository }}
+        run: gh label create $LABEL --repo $REPO --color "D93F0B" --description "PR author detected as automated" --force
 
       - name: Add label
         if: steps.cache.outputs.cache-hit != 'true' && steps.bypass.outputs.is_bot != 'true' && steps.bypass.outputs.skip != 'true' && steps.analyze.outputs.IS_AGENT == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh pr edit ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --add-label "${{ inputs.LABEL }}"
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          LABEL: ${{ inputs.LABEL }}
+        run: gh pr edit $PR_NUMBER --repo $REPO --add-label $LABEL
 
       - name: Comment on PR
         if: steps.cache.outputs.cache-hit != 'true' && steps.bypass.outputs.is_bot != 'true' && steps.bypass.outputs.skip != 'true' && steps.analyze.outputs.IS_AGENT == 'true'
@@ -123,7 +131,7 @@ jobs:
 
       - name: Save scan cache
         if: steps.cache.outputs.cache-hit != 'true' && steps.bypass.outputs.is_bot != 'true' && steps.bypass.outputs.skip != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: .scan-marker
           key: detect-agent-pr-${{ github.event.pull_request.number }}

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -27,21 +27,21 @@ jobs:
     steps:
       - name: Generate a token
         id: bot-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
           app-id: ${{ secrets.BOT_APP_ID }}
           private-key: ${{ secrets.BOT_PRIVATE_KEY }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.head_ref }}
           token: ${{ steps.bot-token.outputs.token }}
 
       - name: Setup PNPM
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org/
@@ -51,12 +51,12 @@ jobs:
         run: pnpm install
 
       - name: Format code
-        run: pnpm run "${{env.COMMAND}}"
+        run: pnpm run $COMMAND
         env:
           COMMAND: ${{ inputs.command }}
 
       - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7.1.0
         env:
           GH_TOKEN: ${{ steps.bot-token.outputs.token }}
         with:

--- a/.github/workflows/mergebot.yml
+++ b/.github/workflows/mergebot.yml
@@ -45,14 +45,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: "bombshell-dev/automation"
           ref: "main"
           path: "automation"
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
 

--- a/.github/workflows/move-issue-to-backlog.yml
+++ b/.github/workflows/move-issue-to-backlog.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Generate a token
         id: bot-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
           app-id: ${{ secrets.BOT_APP_ID }}
           private-key: ${{ secrets.BOT_PRIVATE_KEY }}
@@ -70,6 +70,7 @@ jobs:
       - name: Set fields
         env:
           GH_TOKEN: ${{ steps.bot-token.outputs.token }}
+          STATUS_VALUE: ${{ env.OPTION_ID_STATUS_BACKLOG }}
 
         run: |
           gh api graphql -f query='
@@ -91,4 +92,4 @@ jobs:
                   id
                 }
               }
-            }' -f project=$PROJECT_ID -f item=$ITEM_ID -f status_field=$FIELD_ID_STATUS -f status_value=${{ env.OPTION_ID_STATUS_BACKLOG }} --silent
+            }' -f project=$PROJECT_ID -f item=$ITEM_ID -f status_field=$FIELD_ID_STATUS -f status_value=$STATUS_VALUE --silent

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -23,13 +23,13 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup PNPM
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org/
@@ -42,4 +42,7 @@ jobs:
         run: pnpm run build
 
       - name: Publish Preview
-        run: pnpx pkg-pr-new publish '${{inputs.publish}}' --template '${{inputs.template}}'
+        env:
+          TEMPLATE_GLOB: ${{ inputs.template }}
+          PUBLISH_GLOB: ${{ inputs.publish }}
+        run: pnpx pkg-pr-new publish $PUBLISH_GLOB --template $TEMPLATE_GLOB

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,12 +22,12 @@ jobs:
     steps:
       - name: Generate a token
         id: bot-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
           app-id: ${{ secrets.BOT_APP_ID }}
           private-key: ${{ secrets.BOT_PRIVATE_KEY }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.head_ref }}
           token: ${{ steps.bot-token.outputs.token }}
@@ -38,10 +38,10 @@ jobs:
           git config --global user.email "187071675+bombshell-bot[bot]@users.noreply.github.com"
 
       - name: Setup PNPM
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org/
@@ -49,7 +49,7 @@ jobs:
 
       - name: Update NPM
         # WORKAROUND: The latest version of npm breaks itself whilst installing itself
-        # see https://github.com/npm/cli/issues/9151 
+        # see https://github.com/npm/cli/issues/9151
         run: npm install -g npm@~11.10.0
 
       - name: Install dependencies
@@ -60,7 +60,7 @@ jobs:
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1.8.0
         with:
           version: pnpm exec changeset version
           publish: pnpm exec changeset publish

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -17,13 +17,13 @@ jobs:
         command: ${{ fromJson(inputs.commands) }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup PNPM
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org/
@@ -33,6 +33,6 @@ jobs:
         run: pnpm install
 
       - name: Run ${{ matrix.command }}
-        run: pnpm run "${{env.COMMAND}}"
+        run: pnpm run $COMMAND
         env:
           COMMAND: ${{ matrix.command }}


### PR DESCRIPTION
- Update all workflow actions to their latest versions
- Set all workflow actions to pin to a SHA
- Use env vars instead of templating arbitrary shellscript
