### PR TITLE
chore(ci): harden GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/add-issue-to-project.yml
+++ b/.github/workflows/add-issue-to-project.yml
@@ -10,6 +10,8 @@ on:
         description: 'The GitHub App Private Key for authenticating with the GitHub API'
         required: true
 
+permissions: {}
+
 jobs:
   issue:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches: [main]
 
+permissions: {}
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/detect-agent-backfill.yml
+++ b/.github/workflows/detect-agent-backfill.yml
@@ -16,6 +16,8 @@ on:
         type: boolean
         required: false
 
+permissions: {}
+
 jobs:
   backfill:
     runs-on: ubuntu-latest

--- a/.github/workflows/detect-agent-backfill.yml
+++ b/.github/workflows/detect-agent-backfill.yml
@@ -42,8 +42,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           LABEL: ${{ inputs.LABEL }}
-          REPO: ${{ github.repository }}
-        run: gh label create "$LABEL" --repo "$REPO" --color "D93F0B" --description "PR author detected as automated" --force
+        run: gh label create "$LABEL" --repo "$GITHUB_REPOSITORY" --color "D93F0B" --description "PR author detected as automated" --force
 
       - name: Scan open PRs
         env:

--- a/.github/workflows/detect-agent-backfill.yml
+++ b/.github/workflows/detect-agent-backfill.yml
@@ -20,6 +20,7 @@ permissions: {}
 
 jobs:
   backfill:
+    if: github.repository_owner == 'bombshell-dev'
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -42,7 +43,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           LABEL: ${{ inputs.LABEL }}
           REPO: ${{ github.repository }}
-        run: gh label create $LABEL --repo $REPO --color "D93F0B" --description "PR author detected as automated" --force
+        run: gh label create "$LABEL" --repo "$REPO" --color "D93F0B" --description "PR author detected as automated" --force
 
       - name: Scan open PRs
         env:

--- a/.github/workflows/detect-agent.yml
+++ b/.github/workflows/detect-agent.yml
@@ -30,6 +30,7 @@ permissions: {}
 
 jobs:
   detect:
+    if: github.repository_owner == 'bombshell-dev'
     runs-on: ubuntu-latest
     outputs:
       classification: ${{ steps.analyze.outputs.CLASSIFICATION }}
@@ -61,7 +62,7 @@ jobs:
           fi
           # Check org membership
           if [[ "$BYPASS_MEMBERS" == "true" ]]; then
-            if gh api repos/${{ github.repository }}/collaborators/$PR_AUTHOR --silent 2>/dev/null; then
+            if gh api "repos/$GITHUB_REPOSITORY/collaborators/$PR_AUTHOR" --silent 2>/dev/null; then
               echo "skip=true" >> "$GITHUB_OUTPUT"
             fi
           fi
@@ -71,11 +72,10 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           LABEL: ${{ inputs.LABEL }}
-          REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          gh label create $LABEL --repo $REPO --color "D93F0B" --description "PR author detected as automated" --force
-          gh pr edit $PR_NUMBER --repo $REPO --add-label $LABEL
+          gh label create "$LABEL" --repo "$GITHUB_REPOSITORY" --color "D93F0B" --description "PR author detected as automated" --force
+          gh pr edit "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --add-label "$LABEL"
 
       - name: Checkout
         if: steps.cache.outputs.cache-hit != 'true' && steps.bypass.outputs.is_bot != 'true' && steps.bypass.outputs.skip != 'true'
@@ -108,24 +108,23 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           LABEL: ${{ inputs.LABEL }}
-          REPO: ${{ github.repository }}
-        run: gh label create $LABEL --repo $REPO --color "D93F0B" --description "PR author detected as automated" --force
+        run: gh label create "$LABEL" --repo "$GITHUB_REPOSITORY" --color "D93F0B" --description "PR author detected as automated" --force
 
       - name: Add label
         if: steps.cache.outputs.cache-hit != 'true' && steps.bypass.outputs.is_bot != 'true' && steps.bypass.outputs.skip != 'true' && steps.analyze.outputs.IS_AGENT == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          REPO: ${{ github.repository }}
           LABEL: ${{ inputs.LABEL }}
-        run: gh pr edit $PR_NUMBER --repo $REPO --add-label $LABEL
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: gh pr edit "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --add-label "$LABEL"
 
       - name: Comment on PR
         if: steps.cache.outputs.cache-hit != 'true' && steps.bypass.outputs.is_bot != 'true' && steps.bypass.outputs.skip != 'true' && steps.analyze.outputs.IS_AGENT == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           COMMENT_BODY: ${{ steps.analyze.outputs.COMMENT }}
-        run: gh pr comment ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --body "$COMMENT_BODY"
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --body "$COMMENT_BODY"
 
       - name: Create scan marker
         if: steps.cache.outputs.cache-hit != 'true' && steps.bypass.outputs.is_bot != 'true' && steps.bypass.outputs.skip != 'true'

--- a/.github/workflows/detect-agent.yml
+++ b/.github/workflows/detect-agent.yml
@@ -26,6 +26,8 @@ on:
         description: "Whether the PR author is classified as automated (true/false)"
         value: ${{ jobs.detect.outputs.is_agent }}
 
+permissions: {}
+
 jobs:
   detect:
     runs-on: ubuntu-latest

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -16,6 +16,8 @@ on:
         description: "The GitHub App Private Key for authenticating with the GitHub API"
         required: true
 
+permissions: {}
+
 jobs:
   format:
     if: github.repository_owner == 'bombshell-dev'

--- a/.github/workflows/mergebot.yml
+++ b/.github/workflows/mergebot.yml
@@ -40,6 +40,8 @@ on:
         type: string
         required: false
 
+permissions: {}
+
 jobs:
   post-message:
     runs-on: ubuntu-latest

--- a/.github/workflows/move-issue-to-backlog.yml
+++ b/.github/workflows/move-issue-to-backlog.yml
@@ -10,6 +10,8 @@ on:
         description: 'The GitHub App Private Key for authenticating with the GitHub API'
         required: true
 
+permissions: {}
+
 jobs:
   issue:
     runs-on: ubuntu-latest

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -13,6 +13,8 @@ on:
         required: false
         type: string
 
+permissions: {}
+
 jobs:
   preview:
     if: github.repository_owner == 'bombshell-dev'

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -47,4 +47,4 @@ jobs:
         env:
           TEMPLATE_GLOB: ${{ inputs.template }}
           PUBLISH_GLOB: ${{ inputs.publish }}
-        run: pnpx pkg-pr-new publish $PUBLISH_GLOB --template $TEMPLATE_GLOB
+        run: pnpx pkg-pr-new publish "$PUBLISH_GLOB" --template "$TEMPLATE_GLOB"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,13 +19,13 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup PNPM
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: "pnpm"
@@ -42,7 +42,7 @@ jobs:
         run: pnpm run build
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: build-output
           path: |
@@ -95,7 +95,7 @@ jobs:
         run: pnpm install --ignore-scripts
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: build-output
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,14 +13,51 @@ on:
 permissions: {}
 
 jobs:
+  build:
+    if: github.repository_owner == 'bombshell-dev'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PNPM
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "pnpm"
+
+      - name: Update NPM
+        # WORKAROUND: The latest version of npm breaks itself whilst installing itself
+        # see https://github.com/npm/cli/issues/9151
+        run: npm install -g npm@~11.10.0
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-output
+          path: |
+            packages/*/dist
+          if-no-files-found: ignore
+          retention-days: 1
+
   publish:
+    needs: build
     if: github.repository_owner == 'bombshell-dev'
     runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
       id-token: write
-
     steps:
       - name: Generate a token
         id: bot-token
@@ -54,11 +91,13 @@ jobs:
         # see https://github.com/npm/cli/issues/9151
         run: npm install -g npm@~11.10.0
 
-      - name: Install dependencies
-        run: pnpm install
+      - name: Install dependencies (no scripts)
+        run: pnpm install --ignore-scripts
 
-      - name: Build
-        run: pnpm run build
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-output
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,8 @@ on:
         description: "The GitHub App Private Key for authenticating with the GitHub API"
         required: true
 
+permissions: {}
+
 jobs:
   publish:
     if: github.repository_owner == 'bombshell-dev'

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -9,6 +9,8 @@ on:
           '["lint","test","types"]'
         required: true
 
+permissions: {}
+
 jobs:
   run:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What does this PR do?

Hardens our reusable workflows in response to GHSA-g7cv-rxg3-hmpx (the 2026-05-11 `@tanstack/*` npm supply-chain compromise).

- Adds `permissions: {}` default-deny at workflow level on all 10 workflow files
- Splits `publish.yml` into separate `build` and `publish` jobs so `id-token: write` (npm trusted-publisher OIDC) is scoped to a job that never executes project code; publish job uses `pnpm install --ignore-scripts`
- Pins `actions/upload-artifact` (`043fb46d...`, v7.0.1) and `actions/download-artifact` (`3e5f45b2...`, v8.0.1) — new actions introduced by the publish.yml split
- Re-pins `actions/checkout`, `pnpm/action-setup`, `actions/setup-node` in the new build job to match the SHA pins already used elsewhere in the file
- Routes workflow inputs and event context through `env:` instead of `${{ }}` shell interpolation in `preview.yml`, `detect-agent.yml`, and `detect-agent-backfill.yml`; quotes `"$VAR"` to prevent word-splitting and glob expansion on label/glob inputs
- Adds `if: github.repository_owner == 'bombshell-dev'` owner gate to `detect-agent.yml` and `detect-agent-backfill.yml` (other workflows already had it)
- Adds `.github/dependabot.yml` for automated weekly SHA bumps on GitHub Actions, grouped into a single PR

## Type of change

<!-- Check one. -->

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [x] Chore (dependencies, CI, tooling)

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box. This is fine — we just need to know so reviewers can pay extra attention to edge cases. -->

- [x] This PR includes AI-generated code
