### PR TITLE
Preview Hardened Permissions And Always `pnpm`

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -13,16 +13,10 @@ on:
         required: false
         type: string
 
-permissions: {}
-
 jobs:
   preview:
     if: github.repository_owner == 'bombshell-dev'
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-      id-token: write
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -41,4 +41,4 @@ jobs:
         env:
           TEMPLATE_GLOB: ${{ inputs.template }}
           PUBLISH_GLOB: ${{ inputs.publish }}
-        run: pnpx pkg-pr-new publish "$PUBLISH_GLOB" --template "$TEMPLATE_GLOB"
+        run: pnpx pkg-pr-new publish --pnpm "$PUBLISH_GLOB" --template "$TEMPLATE_GLOB"


### PR DESCRIPTION
## What does this PR do?

Working through setting up a repo and ran into these two issues.

- We don't need `write` permissions for publishing a preview package.
- Also we can always use `pnpm pack` as that is the default expectation. Using `npm` may trigger `devEngines` checks as set in the template.

## Type of change

<!-- Check one. -->

- [x] Bug fix
- [ ] Feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [x] Chore (dependencies, CI, tooling)

## Checklist

- [x] All tests pass (`pnpm test`)
- [x] Files are formatted (`pnpm format`)
- [x] I have added/updated tests for my changes (if applicable)
- [ ] I have added a changeset

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box. This is fine — we just need to know so reviewers can pay extra attention to edge cases. -->

- [ ] This PR includes AI-generated code
